### PR TITLE
Add .gitignore for PlatformIO projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Compiled binary files
+*.bin
+*.elf
+*.hex
+*.map
+
+# PlatformIO build and dependency folders
+.pio/
+.pioenvs/
+.piolibdeps/
+
+# Local IDE settings
+.vscode/
+
+# Miscellaneous
+.DS_Store
+


### PR DESCRIPTION
## Summary
- add `.gitignore` with common Arduino/PlatformIO entries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685acadb35f88331af04089773cedec5