### PR TITLE
Add ESP32 Blink example with install script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.5)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(blink)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# esp
+# ESP32 Blink Beispiel
+
+Dieses Projekt enthält eine minimale Firmware, die die interne LED des ESP32 im Sekundentakt blinken lässt.
+
+## Installation
+
+Das Skript `install.sh` installiert das ESP-IDF falls erforderlich, baut die Firmware und flasht sie auf die Platine. Der serielle Port kann über die Umgebungsvariable `BOARD_PORT` angepasst werden (Standard ist `/dev/ttyUSB0`).
+
+```bash
+./install.sh
+```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+BOARD_PORT=${BOARD_PORT:-/dev/ttyUSB0}
+
+# Check for git
+if ! command -v git >/dev/null 2>&1; then
+  echo "git not found. Please install git." >&2
+  exit 1
+fi
+
+# Get ESP-IDF if not present
+if [ ! -d "$HOME/esp/esp-idf" ]; then
+  mkdir -p "$HOME/esp"
+  git clone --recursive https://github.com/espressif/esp-idf.git "$HOME/esp/esp-idf"
+fi
+
+# Set up ESP-IDF environment
+source "$HOME/esp/esp-idf/export.sh"
+
+idf.py build
+idf.py -p "$BOARD_PORT" flash

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "main.c" INCLUDE_DIRS "")

--- a/main/main.c
+++ b/main/main.c
@@ -1,0 +1,18 @@
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+
+#define BLINK_GPIO GPIO_NUM_2
+
+void app_main(void)
+{
+    gpio_pad_select_gpio(BLINK_GPIO);
+    gpio_set_direction(BLINK_GPIO, GPIO_MODE_OUTPUT);
+
+    while (1) {
+        gpio_set_level(BLINK_GPIO, 0);
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
+        gpio_set_level(BLINK_GPIO, 1);
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
+    }
+}


### PR DESCRIPTION
## Summary
- create ESP-IDF project skeleton for a blink example
- add installation script for setting up ESP-IDF and flashing the board
- document usage in README

## Testing
- `bash -n install.sh`
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acb75d3c4833197e4737d0bd86bde